### PR TITLE
fix: use target FQDN directly for Kerberos SPN when host is already fully qualified

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -282,7 +282,8 @@ class smb(connection):
             self.logger.debug(f"Error adding host {self.host} into db: {e!s}")
 
         # DCOM connection with kerberos needed
-        self.remoteName = self.host if not self.kerberos else f"{self.hostname}.{self.targetDomain}"
+        # When the target is already an FQDN, use it directly so the SPN matches the host's AD registration (e.g. host.aepsc.com, not host.corp.aepsc.com).
+        self.remoteName = self.host if (not self.kerberos or "." in self.host) else f"{self.hostname}.{self.targetDomain}"
 
         # using kdcHost is buggy on impacket when using trust relation between ad so we kdcHost must stay to none if targetdomain is not equal to domain
         if not self.kdcHost and self.domain and self.domain == self.targetDomain:


### PR DESCRIPTION
## Problem

When using Kerberos authentication (`-k` / `--use-kcache`) against a target specified as an FQDN, NXC reconstructs the remote name used for SPN lookup as `{netbios_hostname}.{targetDomain}` (`smb.py:285`):

```python
self.remoteName = self.host if not self.kerberos else f"{self.hostname}.{self.targetDomain}"
```

This breaks in environments where a host's DNS suffix differs from the AD Kerberos realm. For example:

- Target passed: `host.example.com`
- NetBIOS name returned by SMB: `HOST`
- Kerberos realm returned by SMB: `domain.example.com`
- **SPN NXC requests**: `cifs/host.domain.example.com@DOMAIN.EXAMPLE.COM` ❌
- **SPN registered in AD**: `cifs/host.example.com@DOMAIN.EXAMPLE.COM` ✅

The KDC returns `KDC_ERR_S_PRINCIPAL_UNKNOWN` because the reconstructed SPN doesn't match what the machine has registered. To make things worse, the return value of `kerberos_login()` is not checked in the `--use-kcache` path (`connection.py`), so NXC prints "Successfully authenticated using Kerberos cache" even after the failure and then hits a connection reset when trying to enumerate shares.

This is confirmed by Impacket's `smbclient.py -k -debug`, which shows it uses the target hostname as-is for the SPN and lets the KDC resolve it:

```
[+] SPN CIFS/HOST.EXAMPLE.COM@DOMAIN.EXAMPLE.COM not found in cache
[+] AnySPN is True, looking for another suitable SPN
[+] Returning cached credential for KRBTGT/DOMAIN.EXAMPLE.COM@DOMAIN.EXAMPLE.COM
[+] Using TGT from cache
```

## Fix

When the target is already an FQDN (contains a dot), use it directly as `remoteName` so the SPN matches the host's actual AD registration. Only fall back to constructing `{hostname}.{targetDomain}` when a bare hostname (no dot) is passed, since there is no FQDN to use in that case.

```python
self.remoteName = self.host if (not self.kerberos or "." in self.host) else f"{self.hostname}.{self.targetDomain}"
```

## Test plan

- [ ] `nxc smb host.example.com -k --use-kcache --shares` where `host.example.com` has a DNS suffix different from the AD domain — confirm auth succeeds and shares enumerate
- [ ] `nxc smb host.domain.example.com -k --use-kcache --shares` where DNS suffix matches AD domain — confirm no regression
- [ ] `nxc smb BAREHOST -k --use-kcache --shares` passing a bare hostname — confirm fallback to `{hostname}.{domain}` construction still works
- [ ] DCOM execution path with Kerberos — confirm no regression